### PR TITLE
[core] remove global material-ui/icons imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,19 @@
 			"jsx": true
 		}
 	},
+	"rules": {
+		"no-restricted-imports": [
+			"error",
+			{
+				"paths": ["@material-ui/icons"],
+				"patterns": [
+					"@material-ui/*/*/*",
+					"!@material-ui/core/test-utils/*",
+					"!@material-ui/icons/*"
+				]
+			}
+		]
+	},
 	"settings": {
 		"react": {
 			"version": "detect"

--- a/src/renderer/apps/governance/def.ts
+++ b/src/renderer/apps/governance/def.ts
@@ -1,6 +1,6 @@
 import { AppDefinition } from "../../components/app-definition"
 
-import { ThumbsUpDown } from '@material-ui/icons'
+import ThumbsUpDown from '@material-ui/icons/ThumbsUpDown'
 import GovernanceApp from "./governance"
 
 export const Governance: AppDefinition = {

--- a/src/renderer/apps/mento/mento.tsx
+++ b/src/renderer/apps/mento/mento.tsx
@@ -15,7 +15,7 @@ import * as React from 'react'
 import {
 	Box, Select, MenuItem, Typography, Button, Tooltip
 } from '@material-ui/core'
-import { HelpOutline } from '@material-ui/icons'
+import HelpOutline from '@material-ui/icons/HelpOutline'
 
 import AppHeader from '../../components/app-header'
 import ConfirmSwap from './confirm-swap'

--- a/src/renderer/apps/multisig/def.tsx
+++ b/src/renderer/apps/multisig/def.tsx
@@ -1,7 +1,6 @@
-import { Group } from '@material-ui/icons';
-
 import { AppDefinition } from "../../components/app-definition"
 import MultiSigApp from "./multisig"
+import Group from '@material-ui/icons/Group'
 
 export const MultiSig: AppDefinition = {
 	id: "multisig",

--- a/src/renderer/apps/multisig/owners.tsx
+++ b/src/renderer/apps/multisig/owners.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import {
 	Box, Table, TableBody, TableRow, TableCell, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField
 } from "@material-ui/core"
-import { Add } from "@material-ui/icons"
+import Add from "@material-ui/icons/Add"
 
 import LinkedAddress from "../../components/linked-address"
 import NumberInput from '../../components/number-input'

--- a/src/renderer/apps/portfolio/def.ts
+++ b/src/renderer/apps/portfolio/def.ts
@@ -1,7 +1,6 @@
-import { TrendingUp } from '@material-ui/icons'
-
 import { AppDefinition } from "../../components/app-definition"
 import PortfolioApp from "./portfolio"
+import TrendingUp from '@material-ui/icons/TrendingUp'
 
 export const Portfolio: AppDefinition = {
 	id: "portfolio",

--- a/src/renderer/apps/portfolio/portfolio.tsx
+++ b/src/renderer/apps/portfolio/portfolio.tsx
@@ -17,7 +17,8 @@ import {
 	Table, TableHead, TableRow, TableCell, TableBody, FormControlLabel, Switch,
 	Button, IconButton, Tooltip,
 } from '@material-ui/core'
-import { Add, VisibilityOff } from '@material-ui/icons'
+import Add from '@material-ui/icons/Add'
+import VisibilityOff from '@material-ui/icons/VisibilityOff'
 
 import AppHeader from '../../components/app-header'
 import AppContainer from '../../components/app-container'

--- a/src/renderer/apps/send-receive/send-receive.tsx
+++ b/src/renderer/apps/send-receive/send-receive.tsx
@@ -21,7 +21,8 @@ import {
 	ListItemText, ListItemSecondaryAction,
 } from '@material-ui/core'
 import Alert from '@material-ui/lab/Alert'
-import { Close, Search } from '@material-ui/icons'
+import Close from '@material-ui/icons/Close'
+import Search from '@material-ui/icons/Search'
 
 import AddressAutocomplete from '../../components/address-autocomplete'
 import AppHeader from '../../components/app-header'

--- a/src/renderer/coreapp/accounts-app/account-icon.tsx
+++ b/src/renderer/coreapp/accounts-app/account-icon.tsx
@@ -1,6 +1,9 @@
 import * as React from "react"
-import { VpnKey, AccountBalanceWallet, Visibility, Group } from '@material-ui/icons'
 import { SvgIconProps } from "@material-ui/core"
+import VpnKey from '@material-ui/icons/VpnKey'
+import AccountBalanceWallet from '@material-ui/icons/AccountBalanceWallet'
+import Visibility from '@material-ui/icons/Visibility'
+import Group from '@material-ui/icons/Group'
 
 interface AccountIconProps extends SvgIconProps {
 	type: "local" | "ledger" | "multisig" | "address-only",

--- a/src/renderer/coreapp/accounts-app/accounts-app.tsx
+++ b/src/renderer/coreapp/accounts-app/accounts-app.tsx
@@ -10,9 +10,12 @@ import {
 	makeStyles, Tooltip, Box, Button, IconButton, Typography,
 	TextField, Paper,
 } from '@material-ui/core'
-import {
-	Lock, Add, Settings, Backup, Delete, LockOpen
-} from '@material-ui/icons'
+import Lock from '@material-ui/icons/Lock'
+import Add from '@material-ui/icons/Add'
+import Settings from '@material-ui/icons/Settings'
+import Backup from '@material-ui/icons/Backup'
+import Delete from '@material-ui/icons/Delete'
+import LockOpen from '@material-ui/icons/LockOpen'
 
 import AppContainer from '../../components/app-container'
 import AppSection from '../../components/app-section'

--- a/src/renderer/coreapp/accounts-app/add-account.tsx
+++ b/src/renderer/coreapp/accounts-app/add-account.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core'
-import { GetApp } from '@material-ui/icons'
+import GetApp from '@material-ui/icons/GetApp'
 
 import AccountIcon from './account-icon'
 

--- a/src/renderer/coreapp/accounts-app/create-multisig-account.tsx
+++ b/src/renderer/coreapp/accounts-app/create-multisig-account.tsx
@@ -11,7 +11,8 @@ import {
 	Dialog, DialogTitle, DialogContent, DialogActions,
 	Button, TextField, Box, Typography, InputAdornment, IconButton
  } from '@material-ui/core'
-import { Add, Clear } from '@material-ui/icons'
+import Add from '@material-ui/icons/Add'
+import Clear from '@material-ui/icons/Clear'
 
 import NumberInput from '../../components/number-input'
 import { UserError } from '../../../lib/error'

--- a/src/renderer/coreapp/accounts-bar.tsx
+++ b/src/renderer/coreapp/accounts-bar.tsx
@@ -10,7 +10,8 @@ import {
 	makeStyles, IconButton, Select, MenuItem, Box, Typography,
 	Tooltip, Dialog, DialogContent, Paper
 } from '@material-ui/core'
-import { CropFree, FileCopy } from '@material-ui/icons'
+import CropFree from '@material-ui/icons/CropFree'
+import FileCopy from '@material-ui/icons/FileCopy'
 
 import AccountIcon from './accounts-app/account-icon'
 import NetworkIndicator from './network-indicator'

--- a/src/renderer/coreapp/appstore-app/appstore-app.tsx
+++ b/src/renderer/coreapp/appstore-app/appstore-app.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import {
 	Box, Fab, Paper, Typography
 } from '@material-ui/core'
-import { Add } from '@material-ui/icons'
+import Add from '@material-ui/icons/Add'
 
 import AppHeader from '../../components/app-header'
 import Link from '../../components/link'

--- a/src/renderer/coreapp/network-indicator.tsx
+++ b/src/renderer/coreapp/network-indicator.tsx
@@ -13,7 +13,8 @@ import {
 	makeStyles, Tooltip, Button, Dialog, DialogTitle,
 	DialogContent, DialogActions, TextField, LinearProgress,
 } from '@material-ui/core'
-import { Wifi, WifiOff } from '@material-ui/icons'
+import Wifi from '@material-ui/icons/Wifi'
+import WifiOff from '@material-ui/icons/WifiOff'
 
 const useStyles = makeStyles((theme) => ({
 	connected: {

--- a/src/renderer/coreapp/tx-runner/run-txs.tsx
+++ b/src/renderer/coreapp/tx-runner/run-txs.tsx
@@ -20,7 +20,8 @@ import {
 	Paper, Box, Typography, LinearProgress, List, ListItem, ListItemIcon,
 	Button, ListItemText
 } from '@material-ui/core'
-import { Send, CheckCircle } from '@material-ui/icons'
+import Send from '@material-ui/icons/Send'
+import CheckCircle from '@material-ui/icons/CheckCircle'
 
 import TransactionInfo from './transaction-info'
 import PromptLedgerAction from './prompt-ledger-action'

--- a/src/renderer/coreapp/tx-runner/transaction-info.tsx
+++ b/src/renderer/coreapp/tx-runner/transaction-info.tsx
@@ -7,7 +7,8 @@ import {
 	TableContainer, Table, TableBody, TableRow, TableCell,
 	Paper, IconButton
 } from '@material-ui/core'
-import { KeyboardArrowDown, KeyboardArrowUp }  from '@material-ui/icons'
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown'
+import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp'
 import BigNumber from 'bignumber.js'
 
 const TransactionInfo = (props: {

--- a/webpack.renderer.js
+++ b/webpack.renderer.js
@@ -13,25 +13,29 @@ module.exports = (config) => {
 			rule.use = use
 		}
 
-		if (rule.use && rule.use.loader === "babel-loader") {
-			// see: https://material-ui.com/guides/minimizing-bundle-size/#option-2
-			// for more information on @material-ui import transforms.
-			rule.use.options.plugins.push(
-				[
-					'babel-plugin-transform-imports',
-					{
-						'@material-ui/core': {
-							'transform': '@material-ui/core/esm/${member}',
-							'preventFullImport': true
-						},
-						'@material-ui/icons': {
-							'transform': '@material-ui/icons/esm/${member}',
-							'preventFullImport': true
-						}
-					}
-				],
-			)
-		}
+		// if (rule.use && rule.use.loader === "babel-loader") {
+		// 	// see: https://material-ui.com/guides/minimizing-bundle-size/#option-2
+		// 	// for more information on @material-ui import transforms.
+		// 	rule.use.options.plugins.push(
+		// 		[
+		// 			'babel-plugin-transform-imports',
+		// 			{
+		// 				'@material-ui/core': {
+		// 					'transform': '@material-ui/core/esm/${member}',
+		// 					'preventFullImport': true,
+		// 				},
+		// 				'@material-ui/lab': {
+		// 					'transform': '@material-ui/lab/esm/${member}',
+		// 					'preventFullImport': true,
+		// 				},
+		// 				'@material-ui/icons': {
+		// 					'transform': '@material-ui/icons/esm/${member}',
+		// 					'preventFullImport': true,
+		// 				}
+		// 			}
+		// 		],
+		// 	)
+		// }
 	}
 
 	// SVG is already configured for `url-loader` so insert @svgr/webpack loader


### PR DESCRIPTION
* babel transform isn't working so instead of figuring that out, just disallow global icon imports