### PR TITLE
[app/moola] fix moola modifying internal coreErc20 objects

### DIFF
--- a/src/renderer/apps/moola/config.ts
+++ b/src/renderer/apps/moola/config.ts
@@ -19,4 +19,6 @@ export const MOO: moolaToken = {
 	},
 };
 
-export const moolaTokens: moolaToken[] = [...coreErc20s, MOO];
+// NOTE: need to make copy of coreErc20 objects since some of the token internal properties get
+// modified within moola codebase.
+export const moolaTokens: moolaToken[] = [...coreErc20s.map((e) => Object.assign({}, e)), MOO];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,9 +6105,9 @@ bip32@2.0.5:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-"bip39@git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2":
+"bip39@https://github.com/bitcoinjs/bip39#d8ea080a18b40f301d4e2219a2991cd2417e83c2":
   version "3.0.3"
-  resolved "git+https://github.com/bitcoinjs/bip39.git#d8ea080a18b40f301d4e2219a2991cd2417e83c2"
+  resolved "https://github.com/bitcoinjs/bip39#d8ea080a18b40f301d4e2219a2991cd2417e83c2"
   dependencies:
     "@types/node" "11.11.6"
     create-hash "^1.1.0"
@@ -6150,9 +6150,9 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-"bls12377js@git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6":
+"bls12377js@https://github.com/celo-org/bls12377js#cb38a4cfb643c778619d79b20ca3e5283a2122a6":
   version "0.1.0"
-  resolved "git+https://github.com/celo-org/bls12377js.git#cb38a4cfb643c778619d79b20ca3e5283a2122a6"
+  resolved "https://github.com/celo-org/bls12377js#cb38a4cfb643c778619d79b20ca3e5283a2122a6"
   dependencies:
     "@stablelib/blake2xs" "0.10.4"
     "@types/node" "^12.11.7"


### PR DESCRIPTION
@x-moola : there is pretty dangerous practice of mutating objects within Moola app code base like this one:
```
moola.tsx:
	const tokenAddress = selectAddressOrThrow(tokenInfo.addresses);
	tokenInfo.address = tokenAddress;
```

This was affecting other parts of the code too since it was actually modifying "const/readonly" coreErc20 objects because of how code is structured. 

This quick fix resolves issue with coreErc20s but I would in general strongly recommend using immutable/readonly properties, mutating objects like that is bound to cause some serious unpredictable issues in the future.